### PR TITLE
Discontinue Python3.4 support (#28)

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,7 +5,6 @@ dist: xenial # required for Python >= 3.7
 language: python
 
 python:
-  - "3.4"
   - "3.5"
   - "3.6"
   - "3.7"


### PR DESCRIPTION
Reasons:
Python 3.4 EOL reached in 2019

close #28 