### PR TITLE
:sparkles: Count only reachable vertices in topological sorting (#345)

### DIFF
--- a/snippets/graph/topological_sorting.py
+++ b/snippets/graph/topological_sorting.py
@@ -15,6 +15,7 @@ Usage:
         ts.add_edge(frm=ai, to=bi)
 
     is_DAG, orders = ts.sort()
+    is_DAG, orders = ts.sort_only_reachable_vertices_from(start_id=0)
 """
 
 from collections import deque
@@ -43,7 +44,7 @@ class TopologicalSorting:
         self.graph[frm].append(to)
         self.indegrees[to] += 1
 
-    def sort(self) -> Tuple[bool, List[int]]:
+    def sort(self, allow_a_vertex_with_indegree_zero=True) -> Tuple[bool, List[int]]:
         """
         Returns:
             is_DAG: Is it DAG (Directed Acyclic Graph) ?
@@ -59,7 +60,7 @@ class TopologicalSorting:
 
         while que:
             # No more than two vertices with indegree 0 are allowed.
-            if len(que) >= 2:
+            if allow_a_vertex_with_indegree_zero and len(que) >= 2:
                 return False, []
 
             vertex = que.popleft()
@@ -79,3 +80,41 @@ class TopologicalSorting:
             # return True, costs
         else:
             return False, []
+
+    def sort_only_reachable_vertices_from(
+        self, start_id: int = 0
+    ) -> Tuple[bool, List[int]]:
+        """
+        Returns:
+            is_DAG: Is it DAG (Directed Acyclic Graph) ?
+            orders: Order of vertices (1-indexed).
+        """
+        is_DAG, orders = self.sort(allow_a_vertex_with_indegree_zero=False)
+
+        if not is_DAG:
+            return is_DAG, orders
+
+        que = deque([start_id])
+        visited = [False] * self.vertex_count
+
+        while que:
+            cur = que.popleft()
+
+            if visited[cur]:
+                continue
+
+            visited[cur] = True
+
+            for to in self.graph[cur]:
+                if visited[to]:
+                    continue
+
+                que.append(to)
+
+        reachable_orders = list()
+
+        for order in orders:
+            if visited[order]:
+                reachable_orders.append(order + 1)
+
+        return is_DAG, reachable_orders

--- a/tests/test_topological_sorting.py
+++ b/tests/test_topological_sorting.py
@@ -1,20 +1,25 @@
 # -*- coding: utf-8 -*-
 
 from typing import List, Tuple
+
 import pytest
 
 from snippets.graph.topological_sorting import TopologicalSorting
 
 
 class TestTopologicalSorting:
-
-    @pytest.mark.parametrize(('n', 'm', 'graph', 'expected'), [
-        (3, 2, [[3, 1], [2, 3]], (True, [1, 2, 0])),
-        (4, 3, [[1, 2], [2, 3], [3, 4]], (True, [0, 1, 2, 3])),
-        (3, 2, [[3, 1], [3, 2]], (False, [])),
-        (3, 0, [], (False, [])),
-    ])
-    def test_topological_sorting(self, n: int, m: int, graph: List[List[int]], expected: Tuple[bool, List[int]]):
+    @pytest.mark.parametrize(
+        ("n", "m", "graph", "expected"),
+        [
+            (3, 2, [[3, 1], [2, 3]], (True, [1, 2, 0])),
+            (4, 3, [[1, 2], [2, 3], [3, 4]], (True, [0, 1, 2, 3])),
+            (3, 2, [[3, 1], [3, 2]], (False, [])),
+            (3, 0, [], (False, [])),
+        ],
+    )
+    def test_topological_sorting(
+        self, n: int, m: int, graph: List[List[int]], expected: Tuple[bool, List[int]]
+    ) -> None:
         ts = TopologicalSorting(n)
 
         for i in range(m):
@@ -26,6 +31,43 @@ class TestTopologicalSorting:
             ts.add_edge(frm=ai, to=bi)
 
         is_DAG, orders = ts.sort()
+        expected_is_DAG, expected_orders = expected
+
+        assert is_DAG == expected_is_DAG
+        assert orders == expected_orders
+
+    @pytest.mark.parametrize(
+        ("n", "m", "graph", "expected"),
+        [
+            (
+                6,
+                5,
+                [[1, 2], [2, 3], [3, 4], [4, 5], [5, 6]],
+                (True, [1, 2, 3, 4, 5, 6]),
+            ),
+            (8, 4, [[1, 5], [2, 6], [3, 7], [4, 8]], (True, [1, 5])),
+            (
+                6,
+                6,
+                [[1, 2], [1, 3], [1, 4], [2, 3], [2, 5], [4, 5]],
+                (True, [1, 2, 4, 3, 5]),
+            ),
+        ],
+    )
+    def test_topological_sorting_only_reachable_vertices_from(
+        self, n: int, m: int, graph: List[List[int]], expected: Tuple[bool, List[int]]
+    ) -> None:
+        ts = TopologicalSorting(n)
+
+        for i in range(m):
+            # vertex ai -> bi.
+            ai, bi = graph[i]
+            ai -= 1
+            bi -= 1
+
+            ts.add_edge(frm=ai, to=bi)
+
+        is_DAG, orders = ts.sort_only_reachable_vertices_from(start_id=0)
         expected_is_DAG, expected_orders = expected
 
         assert is_DAG == expected_is_DAG


### PR DESCRIPTION
close #345 